### PR TITLE
fix(dark-mode): persist theme on refresh

### DIFF
--- a/Templates/Template_2/src/App.jsx
+++ b/Templates/Template_2/src/App.jsx
@@ -1,19 +1,14 @@
 import Lenis from "lenis";
 import "lenis/dist/lenis.css";
 import { motion } from "motion/react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Navbar from "./components/Nav2.jsx";
-//import { HoverFollowProvider,HoverFollowTrigger,HoverFollowButton } from "./components/Hover.jsx";
-import NoiseEffect from "./components/Noise.jsx"; // Adjust the import path as necessary
+import NoiseEffect from "./components/Noise.jsx";
 import CustomCursor from "./components/CustomCursor.jsx";
 import ScrollToTopButton from "./components/ScrolltoTop.jsx"; 
+
 function App() {
   const [isDark, setIsDark] = useState(false);
-
-  const toggleTheme = () => {
-    setIsDark(!isDark);
-    document.documentElement.classList.toggle("dark");
-  };
   /*
 "font-apple-garamond"
 "font-merapro"
@@ -36,71 +31,79 @@ hover:bg-[var(--color-secondary)]
 bg-[var(--color-primary)]
 */
 
-  // Initialize Lenis
-  const lenis = new Lenis();
+  // Initialize theme from localStorage on component mount
+  useEffect(() => {
+    const savedTheme = localStorage.getItem("theme");
+    if (savedTheme === "dark") {
+      setIsDark(true);
+      document.documentElement.classList.add("dark");
+    } else if (savedTheme === "light") {
+      setIsDark(false);
+      document.documentElement.classList.remove("dark");
+    }
+  }, []);
 
-  // Use requestAnimationFrame to continuously update the scroll
-  function raf(time) {
-    lenis.raf(time);
+  const toggleTheme = () => {
+    const newTheme = !isDark;
+    setIsDark(newTheme);
+    
+    // Update DOM class
+    if (newTheme) {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+    
+    // Store theme preference in localStorage
+    localStorage.setItem("theme", newTheme ? "dark" : "light");
+  };
+
+  // Initialize Lenis with useEffect
+  useEffect(() => {
+    const lenis = new Lenis();
+
+    function raf(time) {
+      lenis.raf(time);
+      requestAnimationFrame(raf);
+    }
+
     requestAnimationFrame(raf);
-  }
-
-  requestAnimationFrame(raf);
-
-  const images = [
-    {
-      src: "https://skiper-ui.com/_next/image?url=%2Fcard%2F2.png&w=640&q=75",
-      alt: "Image 1",
-    },
-    {
-      src: "https://skiper-ui.com/_next/image?url=%2Fcard%2F1.png&w=640&q=75",
-      alt: "Image 2",
-    },
-    {
-      src: "https://skiper-ui.com/_next/image?url=%2Fcard%2F2.png&w=1080&q=75",
-      alt: "Image 3",
-    },
-  ];
-  const [fontLoaded, setFontLoaded] = useState(false);
+    
+    // Cleanup function
+    return () => {
+      // Add any cleanup needed for Lenis
+    };
+  }, []);
 
   return (
     <div className="min-h-screen bg-[var(--color-bg)] text-[var(--color-text)] transition-colors duration-300">
-      {/* Custom Cursor Component */}
       <CustomCursor />
-      <Navbar />
+      <Navbar isDark={isDark} toggleTheme={toggleTheme} />
 
-
-
-    
-
-      {/* Sample Pages/Sections for Scrolling */}
       <section id="home" className="min-h-screen flex items-center justify-center bg-[var(--color-bg)]">
         <div className="text-center">
           <h2 className="text-4xl md:text-6xl font-montblanc font-bold text-[var(--color-text)] mb-4">Home Section</h2>
           <p className="text-lg md:text-xl text-[var(--color-text)] opacity-70 max-w-2xl mx-auto">
             This is the home section. The navbar will automatically highlight "Home" when you're in this area.
           </p>
-            {/*for Hero section with blur and on load word by word animation*/}
-       <h1 className="relative font-apple z-0 mx-auto max-w-4xl text-center pt-20 text-[20px] tracking-tighter text-[var(--color-text)] md:text-4xl lg:text-7xl">
-        {"Welcome to this React Template".split(" ").map((word, index) => (
-          <motion.span
-            key={index}
-            initial={{ opacity: 0, filter: "blur(4px)", y: 10 }}
-            animate={{ opacity: 1, filter: "blur(0px)", y: 0 }}
-            transition={{
-              duration: 0.3,
-              delay: index * 0.1,
-              ease: "easeInOut",
-            }}
-            className="mr-[30px] inline-block"
-          >
-            {word}
-          </motion.span>
-        ))}
-      </h1>
-      {/*hero section end*/}
+          <h1 className="relative font-apple z-0 mx-auto max-w-4xl text-center pt-20 text-[20px] tracking-tighter text-[var(--color-text)] md:text-4xl lg:text-7xl">
+            {"Welcome to this React Template".split(" ").map((word, index) => (
+              <motion.span
+                key={index}
+                initial={{ opacity: 0, filter: "blur(4px)", y: 10 }}
+                animate={{ opacity: 1, filter: "blur(0px)", y: 0 }}
+                transition={{
+                  duration: 0.3,
+                  delay: index * 0.1,
+                  ease: "easeInOut",
+                }}
+                className="mr-[30px] inline-block"
+              >
+                {word}
+              </motion.span>
+            ))}
+          </h1>
         </div>
-        
       </section>
 
       <section id="about" className="min-h-screen flex items-center justify-center bg-[var(--color-primary)]">
@@ -129,8 +132,8 @@ bg-[var(--color-primary)]
           </p>
         </div>
       </section>
-     <ScrollToTopButton />
-      {/* <NoiseEffect /> */}
+      
+      <ScrollToTopButton />
     </div>
   );
 }

--- a/Templates/Template_2/src/components/CustomCursor.jsx
+++ b/Templates/Template_2/src/components/CustomCursor.jsx
@@ -94,28 +94,60 @@ const CustomCursor = () => {
   }, [isMobile]);
 
   // Check if hovering over interactive elements
-  const isHoveringInteractive = (x, y) => {
-    try {
-      if (!document.elementFromPoint || !isFinite(x) || !isFinite(y)) {
-        return false;
-      }
-      
-      const element = document.elementFromPoint(x, y);
-      if (!element) return false;
-      
-      const hoverTags = ["A", "BUTTON", "INPUT", "TEXTAREA", "LABEL", "SELECT"];
-      const tagName = element.tagName;
-      
-      const hasClickHandler = element.onclick !== null || 
-                            element.getAttribute('onclick') !== null ||
-                            element.style.cursor === 'pointer' ||
-                            (element.hasAttribute('role') && element.getAttribute('role') === 'button');
-      
-      return (tagName && hoverTags.includes(tagName)) || hasClickHandler;
-    } catch (error) {
+  // Add this function to check if element is interactive
+const isElementInteractive = (element) => {
+  if (!element) return false;
+  
+  // Check common interactive elements
+  const interactiveSelectors = [
+    'a', 'button', 'input', 'textarea', 'select', 'label',
+    '[role="button"]', '[role="link"]', '[tabindex]',
+    '[onclick]', '[data-clickable]'
+  ];
+  
+  // Check if element matches any interactive selector
+  if (interactiveSelectors.some(selector => element.matches(selector))) {
+    return true;
+  }
+  
+  // Check if element has cursor: pointer style
+  const style = window.getComputedStyle(element);
+  if (style.cursor === 'pointer' || style.cursor === 'grab') {
+    return true;
+  }
+  
+  // Check if element is contenteditable
+  if (element.hasAttribute('contenteditable')) {
+    return true;
+  }
+  
+  return false;
+};
+
+// Update the isHoveringInteractive function
+const isHoveringInteractive = (x, y) => {
+  try {
+    if (!document.elementFromPoint || !isFinite(x) || !isFinite(y)) {
       return false;
     }
-  };
+    
+    const element = document.elementFromPoint(x, y);
+    if (!element) return false;
+    
+    // Check if the element or any of its parents are interactive
+    let currentElement = element;
+    while (currentElement && currentElement !== document.body) {
+      if (isElementInteractive(currentElement)) {
+        return true;
+      }
+      currentElement = currentElement.parentElement;
+    }
+    
+    return false;
+  } catch (error) {
+    return false;
+  }
+};
 
   // Mouse move handler
   const handleMouseMove = (e) => {

--- a/Templates/Template_2/src/components/ErrorBoundary.jsx
+++ b/Templates/Template_2/src/components/ErrorBoundary.jsx
@@ -1,0 +1,27 @@
+// ErrorBoundary.jsx
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('Error caught by boundary:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <h1>Something went wrong.</h1>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/Templates/Template_2/src/components/Nav1.jsx
+++ b/Templates/Template_2/src/components/Nav1.jsx
@@ -1,5 +1,7 @@
-import { useState } from 'react';
-import { Squeeze as Hamburger } from 'hamburger-react'
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Squeeze as Hamburger } from 'hamburger-react';
+
 const Navbar = ({ 
   logo = "ANSH DHANANI", 
   menuItems = ['WORK', 'ABOUT', 'SERVICES', 'CONTACT'],
@@ -8,6 +10,19 @@ const Navbar = ({
   toggleTheme = () => {}
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+
+  // Check if device is mobile
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
+    
+    checkMobile();
+    window.addEventListener('resize', checkMobile);
+    
+    return () => window.removeEventListener('resize', checkMobile);
+  }, []);
 
   const toggleMenu = () => {
     setIsMenuOpen(!isMenuOpen);
@@ -15,50 +30,107 @@ const Navbar = ({
 
   const handleMenuItemClick = (item) => {
     onMenuClick(item);
-    setIsMenuOpen(false); // Close menu after clicking
+    setIsMenuOpen(false);
+  };
+
+  // Animation variants for framer motion
+  const menuVariants = {
+    open: {
+      clipPath: `circle(150% at ${isMobile ? 'calc(100% - 30px)' : 'calc(100% - 70px)'} 0)`,
+      transition: {
+        type: "spring",
+        stiffness: 20,
+        restDelta: 2
+      }
+    },
+    closed: {
+      clipPath: "circle(0% at calc(100% - 70px) 0)",
+      transition: {
+        delay: 0.5,
+        type: "spring",
+        stiffness: 400,
+        damping: 40
+      }
+    }
+  };
+
+  const itemVariants = {
+    open: {
+      y: 0,
+      opacity: 1,
+      transition: {
+        y: { stiffness: 1000, velocity: -100 }
+      }
+    },
+    closed: {
+      y: 50,
+      opacity: 0,
+      transition: {
+        y: { stiffness: 1000 }
+      }
+    }
   };
 
   return (
     <>
       {/* Header */}
-      <header className="fixed top-0 left-0 w-full h-10 bg-[var(--color-bg-tertiary)] border-b border-[var(--color-border)] flex items-center justify-between px-4 z-50">
+      <header className="fixed top-0 left-0 w-full h-20 bg-[var(--color-bg-tertiary)] border-b border-[var(--color-border)] flex items-center justify-between px-4 md:px-8 z-50">
         
         <div className="w-12"></div>
 
-        {/*Nav-items*/}
-      <div id="nav" className="hidden md:grid grid-cols-4 gap-8 p-2 bg-[var(--color-bg-tertiary)]">
-      {menuItems.map((item) => (
-      <div
-      key={item}
-      className="navbar-items text-center font-semibold text-[var(--color-text)] hover:text-blue-500 cursor-pointer"
-     >
-      {item}
-    </div>
-    ))}
-    </div>
-         {/* Logo */}
-        <h1 className="text-[var(--color-text)] justify-center ml-[55px] pl-4 text-lg md:text-2xl font-bold tracking-wider whitespace-nowrap flex-shrink-0">
+        {/* Desktop Nav Items */}
+        <div id="nav" className="hidden md:flex gap-8 p-2 bg-[var(--color-bg-tertiary)]">
+          {menuItems.map((item) => (
+            <motion.div
+              key={item}
+              className="navbar-items text-center font-semibold text-[var(--color-text)] hover:text-blue-500 cursor-pointer relative"
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
+            >
+              {item}
+              <motion.div 
+                className="absolute bottom-0 left-0 w-0 h-0.5 bg-blue-500"
+                whileHover={{ width: "100%" }}
+                transition={{ duration: 0.3 }}
+              />
+            </motion.div>
+          ))}
+        </div>
+        
+        {/* Logo */}
+        <motion.h1 
+          className="text-[var(--color-text)] text-lg md:text-2xl font-bold tracking-wider whitespace-nowrap flex-shrink-0"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.5 }}
+        >
           {logo}
-        </h1>
-           {/* Theme Toggle */}
-        <button
+        </motion.h1>
+        
+        {/* Theme Toggle */}
+        <motion.button
           onClick={toggleTheme}
           aria-label="Toggle Dark Mode"
-          className={`w-14 h-8 fixed flex items-center p-1 rounded-full transition-colors duration-300 mr-4 ${
+          className={`w-14 h-8 flex items-center p-1 rounded-full transition-colors duration-300 mr-4 ${
             isDark ? "bg-slate-700" : "bg-gray-300"
           }`}
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.9 }}
         >
-          <span
-            className={`w-6 h-6 bg-white rounded-full shadow-md transform transition-transform duration-300 ${
+          <motion.span
+            className={`w-6 h-6 bg-white rounded-full shadow-md flex items-center justify-center text-sm ${
               isDark ? "translate-x-6" : "translate-x-0"
-            } flex items-center justify-center text-sm`}
+            }`}
+            layout
+            transition={{ type: "spring", stiffness: 500, damping: 30 }}
           >
-          </span>
-        </button>
+            {isDark ? "🌙" : "☀️"}
+          </motion.span>
+        </motion.button>
 
-     {/* Hamburger Button */}
-       <div className="w-28 h-20 flex justify-center items-center md:hidden">
-        <Hamburger
+        {/* Hamburger Button */}
+        <div className="w-28 h-20 flex justify-center items-center md:hidden">
+          <Hamburger
             toggled={isMenuOpen}
             toggle={toggleMenu}
             size={27}
@@ -70,88 +142,81 @@ const Navbar = ({
             distance={10}
             label="Toggle Menu"
             className="z-50"
-         />
-      </div>
-      </header>
-      {/* Navigation Menu */}
-      <nav className={`fixed top-0 left-0 w-full h-full flex flex-col justify-center items-center overflow-hidden ${isMenuOpen ? 'z-30 pointer-events-auto' : 'z-30 pointer-events-none'}`}>
-        <div 
-          className="relative z-10 w-full h-full flex flex-col"
-          style={{
-            clipPath: isMenuOpen ? 'circle(150% at top right)' : 'circle(0% at calc(100% - 70px) 0) ',    
-            transition: isMenuOpen ? 'clip-path 2s cubic-bezier(0.83,-0.02,0.00,1.02)' : 'clip-path 0.6s ease-in'
-          }}
-        >
-          {/* Dark background for revealed content */}
-          <div className="absolute inset-0 bg-[var(--color-bg-tertiary)]"></div>
-        
-          {/* Close Button */}
-         
-
-   
-
-          {/* Menu Items - Centered with Scroll */}
-          <div className="flex-1 flex flex-col justify-center relative z-10 py-20">
-            <div className="max-h-[50vh] overflow-y-scroll scrollbar-hide" style={{scrollbarWidth: 'none', msOverflowStyle: 'none'}}>
-              <ul className="list-none text-center">
-                {menuItems.map((item, index) => (
-                  <li key={item} className="relative overflow-hidden">
-                    <button
-                      onClick={() => handleMenuItemClick(item)}
-                      onMouseEnter={(e) => {
-                        const rect = e.currentTarget.getBoundingClientRect();
-                        const mouseY = e.clientY;
-                        const elementCenter = rect.top + rect.height / 2;
-                        const hoverBg = e.currentTarget.querySelector('.hover-bg');
-                        
-                        if (mouseY < elementCenter) {
-                          // Mouse entered from top
-                          hoverBg.style.transformOrigin = 'top';
-                        } else {
-                          // Mouse entered from bottom
-                          hoverBg.style.transformOrigin = 'bottom';
-                        }
-                      }}
-                      className={`no-underline text-3xl md:text-6xl font-bold uppercase tracking-wider block py-3 bg-transparent border-none cursor-pointer w-full text-center text-[var(--color-text)] relative z-10 group ${
-                        item === 'SHOP' ? 'flex items-center justify-center gap-4' : ''
-                      }`}
-                    >
-                      {/* Hover background that grows from mouse direction */}
-                      <div className="hover-bg absolute inset-0 bg-[var(--color-primary)] transform scale-y-0 group-hover:scale-y-100 transition-transform duration-300 origin-bottom"></div>
-                      
-                      {/* Text content */}
-                      <span className="relative z-10 group-hover:text-[var(--color-text-inverse)] transition-colors duration-300 px-8">
-                        {item}
-                        {item === 'SHOP' && <span className="text-3xl ml-4">↗</span>}
-                      </span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
-
-          {/* Footer Links */}
-          <div className="grid grid-cols-4 gap-0 border-t border-[var(--color-border)] relative z-10">
-            <button className="text-[var(--color-text)] text-sm font-bold tracking-wider py-6 px-4 border-r border-[var(--color-border)] bg-transparent border-none cursor-pointer hover:bg-[var(--color-primary)] hover:text-[var(--color-text-inverse)] transition-colors flex items-center justify-between">
-              <span>JOURNAL</span>
-              <span className="text-lg">📄</span>
-            </button>
-            <button className="text-[var(--color-text)] text-sm font-bold tracking-wider py-6 px-4 border-r border-[var(--color-border)] bg-transparent border-none cursor-pointer hover:bg-[var(--color-primary)] hover:text-[var(--color-text-inverse)] transition-colors flex items-center justify-between">
-              <span>SHOP</span>
-              <span className="text-lg">👁</span>
-            </button>
-            <button className="text-[var(--color-text)] text-sm font-bold tracking-wider py-6 px-4 border-r border-[var(--color-border)] bg-transparent border-none cursor-pointer hover:bg-[var(--color-primary)] hover:text-[var(--color-text-inverse)] transition-colors flex items-center justify-between">
-              <span>LINKEDIN</span>
-              <span className="text-lg">↗</span>
-            </button>
-            <button className="text-[var(--color-text)] text-sm font-bold tracking-wider py-6 px-4 bg-transparent border-none cursor-pointer hover:bg-[var(--color-primary)] hover:text-[var(--color-text-inverse)] transition-colors flex items-center justify-between">
-              <span>INSTAGRAM</span>
-              <span className="text-lg">↗</span>
-            </button>
-          </div>
+          />
         </div>
-      </nav>
+      </header>
+
+      {/* Navigation Menu */}
+      <AnimatePresence>
+        {isMenuOpen && (
+          <motion.nav 
+            className="fixed top-0 left-0 w-full h-full flex flex-col justify-center items-center overflow-hidden z-30"
+            initial="closed"
+            animate="open"
+            exit="closed"
+            variants={menuVariants}
+          >
+            <div className="absolute inset-0 bg-[var(--color-bg-tertiary)]"></div>
+            
+            {/* Menu Items */}
+            <div className="flex-1 flex flex-col justify-center relative z-10 py-20">
+              <div className="max-h-[50vh] overflow-y-auto scrollbar-hide">
+                <motion.ul className="list-none text-center">
+                  {menuItems.map((item, index) => (
+                    <motion.li 
+                      key={item} 
+                      className="relative overflow-hidden"
+                      variants={itemVariants}
+                      whileHover={{ scale: 1.05 }}
+                      whileTap={{ scale: 0.95 }}
+                      custom={index}
+                    >
+                      <button
+                        onClick={() => handleMenuItemClick(item)}
+                        className="no-underline text-3xl md:text-6xl font-bold uppercase tracking-wider block py-3 bg-transparent border-none cursor-pointer w-full text-center text-[var(--color-text)] relative z-10 group"
+                      >
+                        {/* Hover background with directional effect */}
+                        <motion.div 
+                          className="hover-bg absolute inset-0 bg-[var(--color-primary)] transform scale-y-0 origin-center"
+                          whileHover={{ scaleY: 1 }}
+                          transition={{ duration: 0.3 }}
+                        />
+                        
+                        {/* Text content */}
+                        <span className="relative z-10 group-hover:text-[var(--color-text-inverse)] transition-colors duration-300 px-8">
+                          {item}
+                        </span>
+                      </button>
+                    </motion.li>
+                  ))}
+                </motion.ul>
+              </div>
+            </div>
+
+            {/* Footer Links */}
+            <motion.div 
+              className="grid grid-cols-2 md:grid-cols-4 gap-0 border-t border-[var(--color-border)] relative z-10 w-full"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.5 }}
+            >
+              {['JOURNAL', 'SHOP', 'LINKEDIN', 'INSTAGRAM'].map((item, index) => (
+                <motion.button 
+                  key={item}
+                  className="text-[var(--color-text)] text-sm font-bold tracking-wider py-6 px-4 border-r border-[var(--color-border)] bg-transparent border-none cursor-pointer hover:bg-[var(--color-primary)] hover:text-[var(--color-text-inverse)] transition-colors flex items-center justify-between"
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.95 }}
+                >
+                  <span>{item}</span>
+                  <span className="text-lg">
+                    {index === 0 ? '📄' : index === 1 ? '👁' : '↗'}
+                  </span>
+                </motion.button>
+              ))}
+            </motion.div>
+          </motion.nav>
+        )}
+      </AnimatePresence>
       
       {/* Spacer for fixed header */}
       <div className="h-20"></div>

--- a/Templates/Template_2/src/components/Nav2.jsx
+++ b/Templates/Template_2/src/components/Nav2.jsx
@@ -1,6 +1,38 @@
 import React from "react";
 
-const Navbar = () => {
+const ThemeToggle = ({ isDark, toggleTheme }) => {
+  return (
+    <div
+      onClick={toggleTheme}
+      className="relative cursor-pointer font-montblanc text-sm"
+    >
+      <div className="flex">
+        <span
+          className={`transition-opacity duration-300 ${
+            isDark ? "opacity-50" : "opacity-100"
+          }`}
+        >
+          LIGHT
+        </span>
+        <span className="mx-1 opacity-30">/</span>
+        <span
+          className={`transition-opacity duration-300 ${
+            isDark ? "opacity-100" : "opacity-50"
+          }`}
+        >
+          DARK
+        </span>
+      </div>
+      <div className="absolute bottom-0 left-0 w-full h-px bg-current opacity-20"></div>
+      <div
+        className="absolute bottom-0 h-0.5 bg-current transition-all duration-500"
+        style={{ width: "45%", left: isDark ? "55%" : "0%" }}
+      ></div>
+    </div>
+  );
+};
+
+const Navbar = ({ isDark, toggleTheme }) => {
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
   const [activeItem, setActiveItem] = React.useState("Home");
   const [isMobile, setIsMobile] = React.useState(window.innerWidth < 640);
@@ -25,13 +57,11 @@ const Navbar = () => {
     setActiveItem(item);
     setIsMenuOpen(false);
 
-    // Update button text
     document.querySelector(".menu-text").textContent = "MENU";
     document.querySelectorAll(".arrow").forEach((arrow) => {
       arrow.classList.remove("rotate-180");
     });
 
-    // Scroll to section
     const sectionId = item.toLowerCase();
     const element = document.getElementById(sectionId);
     if (element) {
@@ -54,7 +84,6 @@ const Navbar = () => {
       const scrollPosition = window.scrollY;
       const windowHeight = window.innerHeight;
 
-      // Simple logic: change active item based on scroll position
       if (scrollPosition < windowHeight * 0.5) {
         setActiveItem("Home");
       } else if (scrollPosition < windowHeight * 1.5) {
@@ -84,13 +113,11 @@ const Navbar = () => {
   return (
     <div className="navbar-container">
       {/* Fixed Site Name */}
-      <div
-        className="fixed top-7 left-5 sm:top-10 sm:left-14 z-[70] text-4xl sm:text-5xl font-montblanc font-bold"
-       // style={{ mixBlendMode: "difference", color: "rgb(255, 255, 255)" }}
-  
-      >
+      <div className="fixed top-7 left-5 sm:top-10 sm:left-14 z-[70] text-4xl sm:text-5xl font-montblanc font-bold">
         SITE NAME
       </div>
+
+      {/* Menu Button */}
       <div
         onClick={toggleMenu}
         className="fixed top-4 right-4 sm:top-8 sm:right-14 z-[71] flex items-center justify-between gap-2 sm:gap-3 p-3 sm:p-4 pl-4 sm:pl-6 pr-3 sm:pr-5 bg-[var(--color-primary)] border-b-[1px] border-[var(--color-contrast)] rounded-full transition-all duration-300 hover:scale-105 active:scale-95"
@@ -118,6 +145,7 @@ const Navbar = () => {
         </div>
       </div>
 
+      {/* Menu Content */}
       <div
         className="fixed bg-[var(--color-contrast)] z-[60] rounded-[20px] sm:rounded-[40px] overflow-hidden"
         style={{
@@ -158,11 +186,13 @@ const Navbar = () => {
               </span>
             </div>
           ))}
+
+          {/* ✅ Theme Toggle Added Here */}
           <div
-            className="text-[var(--color-bg)] pt-4 cursor-pointer hover:opacity-60 transition-all duration-300"
+            className="text-[var(--color-bg)] pt-4 cursor-pointer"
             onClick={(e) => {
               e.stopPropagation();
-              document.documentElement.classList.toggle("dark");
+              toggleTheme();
             }}
             style={{
               opacity: isMenuOpen ? 1 : 0,
@@ -173,7 +203,7 @@ const Navbar = () => {
                 : "opacity 0.2s ease-out",
             }}
           >
-            <div>Dark / Light</div>
+            <ThemeToggle isDark={isDark} toggleTheme={toggleTheme} />
           </div>
         </div>
       </div>

--- a/Templates/Template_2/src/components/ScrolltoTop.jsx
+++ b/Templates/Template_2/src/components/ScrolltoTop.jsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 
 const ScrollToTopButton = () => {
   const [isVisible, setIsVisible] = useState(false);
 
-  // Show button when scrollY > 300
   useEffect(() => {
     const toggleVisibility = () => {
       setIsVisible(window.scrollY > 300);
@@ -13,7 +13,6 @@ const ScrollToTopButton = () => {
     return () => window.removeEventListener("scroll", toggleVisibility);
   }, []);
 
-  // Scroll to top smoothly
   const scrollToTop = () => {
     window.scrollTo({
       top: 0,
@@ -21,17 +20,36 @@ const ScrollToTopButton = () => {
     });
   };
 
-  if (!isVisible) return null;
-
   return (
-   <button
-  onClick={scrollToTop}
-  title="Go to top"
-  style={{ backgroundColor: "var(--color-secondary)" }}
-  className="fixed bottom-8 right-8 z-50 hover:brightness-110 text-white p-3 rounded-full text-xl shadow-lg transition-transform transform hover:scale-110"
->
-  ⮝
-</button>
+    <AnimatePresence>
+      {isVisible && (
+        <motion.button
+          onClick={scrollToTop}
+          title="Go to top"
+          className="fixed bottom-8 right-8 z-50 p-3 rounded-full text-xl shadow-lg bg-[var(--color-primary)] text-white"
+          initial={{ opacity: 0, scale: 0.5 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0, scale: 0.5 }}
+          whileHover={{ 
+            scale: 1.1,
+            backgroundColor: "var(--color-secondary)"
+          }}
+          whileTap={{ scale: 0.9 }}
+          transition={{ type: "spring", stiffness: 400, damping: 17 }}
+        >
+          <motion.span
+            animate={{ y: [0, -2, 0] }}
+            transition={{ 
+              duration: 1.5,
+              repeat: Infinity,
+              repeatType: "reverse"
+            }}
+          >
+            ⮝
+          </motion.span>
+        </motion.button>
+      )}
+    </AnimatePresence>
   );
 };
 

--- a/Templates/Template_2/src/main.jsx
+++ b/Templates/Template_2/src/main.jsx
@@ -1,7 +1,9 @@
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
-
+import ErrorBoundary from "./components/ErrorBoundary.jsx";
 createRoot(document.getElementById('root')).render(
-  <App />,
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>,
 )

--- a/Templates/Template_3/src/App.jsx
+++ b/Templates/Template_3/src/App.jsx
@@ -1,50 +1,57 @@
 import Lenis from "lenis";
 import "lenis/dist/lenis.css";
 import { motion } from "motion/react";
-import { useState } from "react";
+import { useState, useEffect } from "react"; // Added useEffect import
 import Navbar from "./components/Nav1";
-//import { HoverFollowProvider,HoverFollowTrigger,HoverFollowButton } from "./components/Hover.jsx";
-import NoiseEffect from "./components/Noise.jsx"; // Adjust the import path as necessary
+import NoiseEffect from "./components/Noise.jsx";
 import CustomCursor from "./components/CustomCursor.jsx";
+
 function App() {
   const [isDark, setIsDark] = useState(false);
 
+  // Initialize theme from localStorage on component mount
+  useEffect(() => {
+    const savedTheme = localStorage.getItem("theme");
+    if (savedTheme === "dark") {
+      setIsDark(true);
+      document.documentElement.classList.add("dark");
+    } else if (savedTheme === "light") {
+      setIsDark(false);
+      document.documentElement.classList.remove("dark");
+    }
+  }, []);
+
   const toggleTheme = () => {
-    setIsDark(!isDark);
-    document.documentElement.classList.toggle("dark");
+    const newTheme = !isDark;
+    setIsDark(newTheme);
+    
+    // Update DOM class
+    if (newTheme) {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+    
+    // Store theme preference in localStorage
+    localStorage.setItem("theme", newTheme ? "dark" : "light");
   };
-  /*
-"font-apple-garamond"
-"font-merapro"
-"font-boone"
-"font-default-lingo"    
-"font-minecraft"
-"font-montblanc"
-"font-palmore"
-"font-tan-kulture"
-"font-gridular"
-"font-telegraf"
-*/
 
-  // for colour variables use the following format:
-  /**
-bg-[var(--color-bg)]
-text-[var(--color-text)]
-border-[var(--color-border)]
-hover:bg-[var(--color-secondary)]
-bg-[var(--color-primary)]
-*/
+  // Initialize Lenis with useEffect
+  useEffect(() => {
+    const lenis = new Lenis();
 
-  // Initialize Lenis
-  const lenis = new Lenis();
+    function raf(time) {
+      lenis.raf(time);
+      requestAnimationFrame(raf);
+    }
 
-  // Use requestAnimationFrame to continuously update the scroll
-  function raf(time) {
-    lenis.raf(time);
     requestAnimationFrame(raf);
-  }
-
-  requestAnimationFrame(raf);
+    
+    // Cleanup function
+    return () => {
+      // Add any cleanup needed for Lenis
+    };
+  }, []);
 
   const images = [
     {
@@ -64,14 +71,11 @@ bg-[var(--color-primary)]
 
   return (
     <div className="min-h-screen bg-[var(--color-bg)] text-[var(--color-text)] transition-colors duration-300">
-      {/* Custom Cursor Component */}
       <CustomCursor />
-      <Navbar isDark={isDark} toggleTheme={toggleTheme} />
-
-
+      <Navbar isDark={isDark} toggleTheme={toggleTheme} /> {/* Added props */}
 
       {/*for Hero section with blur and on load word by word animation*/}
-       <h1 className="relative font-apple z-0 mx-auto max-w-4xl text-center pt-20 text-[20px] tracking-tighter text-[var(--color-text)] md:text-4xl lg:text-7xl">
+      <h1 className="relative font-apple z-0 mx-auto max-w-4xl text-center pt-20 text-[20px] tracking-tighter text-[var(--color-text)] md:text-4xl lg:text-7xl">
         {"Welcome to this React Template".split(" ").map((word, index) => (
           <motion.span
             key={index}

--- a/Templates/Template_3/src/components/ErrorBoundary.jsx
+++ b/Templates/Template_3/src/components/ErrorBoundary.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null, errorInfo: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({
+      error: error,
+      errorInfo: errorInfo
+    });
+    console.error('Error caught by boundary:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4 bg-red-100 text-red-800">
+          <h2>Something went wrong.</h2>
+          <details style={{ whiteSpace: 'pre-wrap' }}>
+            {this.state.error && this.state.error.toString()}
+            <br />
+            {this.state.errorInfo.componentStack}
+          </details>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/Templates/Template_3/src/components/Nav1.jsx
+++ b/Templates/Template_3/src/components/Nav1.jsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 import { Squeeze as Hamburger } from 'hamburger-react'
+
 const Navbar = ({ 
   logo = "ANSH DHANANI", 
   menuItems = ['WORK', 'ABOUT', 'SERVICES', 'CONTACT'],
   onMenuClick = () => {},
   isDark = false,
-  toggleTheme = () => {}
+  toggleTheme = () => {} // Added props
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
@@ -26,26 +27,28 @@ const Navbar = ({
         <div className="w-12"></div>
 
         {/*Nav-items*/}
-      <div id="nav" className="hidden md:grid grid-cols-4 gap-8 p-2 bg-[var(--color-bg-tertiary)]">
-      {menuItems.map((item) => (
-      <div
-      key={item}
-      className="navbar-items text-center font-semibold text-[var(--color-text)] hover:text-blue-500 cursor-pointer"
-     >
-      {item}
-    </div>
-    ))}
-    </div>
-         {/* Logo */}
+        <div id="nav" className="hidden md:grid grid-cols-4 gap-8 p-2 bg-[var(--color-bg-tertiary)]">
+          {menuItems.map((item) => (
+            <div
+              key={item}
+              className="navbar-items text-center font-semibold text-[var(--color-text)] hover:text-blue-500 cursor-pointer"
+            >
+              {item}
+            </div>
+          ))}
+        </div>
+        
+        {/* Logo */}
         <h1 className="text-[var(--color-text)] justify-center ml-[55px] pl-4 text-lg md:text-2xl font-bold tracking-wider whitespace-nowrap flex-shrink-0">
           {logo}
         </h1>
-           {/* Theme Toggle */}
+        
+        {/* Theme Toggle */}
         <button
-          onClick={toggleTheme}
+          onClick={toggleTheme} // Use the passed toggleTheme function
           aria-label="Toggle Dark Mode"
           className={`w-14 h-8 fixed flex items-center p-1 rounded-full transition-colors duration-300 mr-4 ${
-            isDark ? "bg-slate-700" : "bg-gray-300"
+            isDark ? "bg-blue-700" : "bg-gray-300"
           }`}
         >
           <span
@@ -56,9 +59,9 @@ const Navbar = ({
           </span>
         </button>
 
-     {/* Hamburger Button */}
-       <div className="w-28 h-20 flex justify-center items-center md:hidden">
-        <Hamburger
+        {/* Hamburger Button */}
+        <div className="w-28 h-20 flex justify-center items-center md:hidden">
+          <Hamburger
             toggled={isMenuOpen}
             toggle={toggleMenu}
             size={27}
@@ -70,9 +73,10 @@ const Navbar = ({
             distance={10}
             label="Toggle Menu"
             className="z-50"
-         />
-      </div>
+          />
+        </div>
       </header>
+      
       {/* Navigation Menu */}
       <nav className={`fixed top-0 left-0 w-full h-full flex flex-col justify-center items-center overflow-hidden ${isMenuOpen ? 'z-30 pointer-events-auto' : 'z-30 pointer-events-none'}`}>
         <div 
@@ -85,11 +89,6 @@ const Navbar = ({
           {/* Dark background for revealed content */}
           <div className="absolute inset-0 bg-[var(--color-bg-tertiary)]"></div>
         
-          {/* Close Button */}
-         
-
-   
-
           {/* Menu Items - Centered with Scroll */}
           <div className="flex-1 flex flex-col justify-center relative z-10 py-20">
             <div className="max-h-[50vh] overflow-y-scroll scrollbar-hide" style={{scrollbarWidth: 'none', msOverflowStyle: 'none'}}>

--- a/Templates/brand_template1/src/App.jsx
+++ b/Templates/brand_template1/src/App.jsx
@@ -1,52 +1,59 @@
 import Lenis from "lenis";
 import "lenis/dist/lenis.css";
 import { motion } from "motion/react";
-import { useState } from "react";
+import { useState, useEffect } from "react"; // Added useEffect import
 import Navbar from "./components/Nav2.jsx";
-//import { HoverFollowProvider,HoverFollowTrigger,HoverFollowButton } from "./components/Hover.jsx";
-import NoiseEffect from "./components/Noise.jsx"; // Adjust the import path as necessary
+import NoiseEffect from "./components/Noise.jsx";
 import CustomCursor from "./components/CustomCursor.jsx";
 import ScrollToTopButton from "./components/ScrolltoTop.jsx"; 
 import GradualBlurEffect from "./components/Gradualblur.jsx";
+
 function App() {
   const [isDark, setIsDark] = useState(false);
 
+  // Initialize theme from localStorage on component mount
+  useEffect(() => {
+    const savedTheme = localStorage.getItem("theme");
+    if (savedTheme === "dark") {
+      setIsDark(true);
+      document.documentElement.classList.add("dark");
+    } else if (savedTheme === "light") {
+      setIsDark(false);
+      document.documentElement.classList.remove("dark");
+    }
+  }, []);
+
   const toggleTheme = () => {
-    setIsDark(!isDark);
-    document.documentElement.classList.toggle("dark");
+    const newTheme = !isDark;
+    setIsDark(newTheme);
+    
+    // Update DOM class
+    if (newTheme) {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+    
+    // Store theme preference in localStorage
+    localStorage.setItem("theme", newTheme ? "dark" : "light");
   };
-  /*
-"font-apple-garamond"
-"font-merapro"
-"font-boone"
-"font-default-lingo"    
-"font-minecraft"
-"font-montblanc"
-"font-palmore"
-"font-tan-kulture"
-"font-gridular"
-"font-telegraf"
-*/
 
-  // for colour variables use the following format:
-  /**
-bg-[var(--color-bg)]
-text-[var(--color-text)]
-border-[var(--color-border)]
-hover:bg-[var(--color-secondary)]
-bg-[var(--color-primary)]
-*/
+  // Initialize Lenis with useEffect
+  useEffect(() => {
+    const lenis = new Lenis();
 
-  // Initialize Lenis
-  const lenis = new Lenis();
+    function raf(time) {
+      lenis.raf(time);
+      requestAnimationFrame(raf);
+    }
 
-  // Use requestAnimationFrame to continuously update the scroll
-  function raf(time) {
-    lenis.raf(time);
     requestAnimationFrame(raf);
-  }
-
-  requestAnimationFrame(raf);
+    
+    // Cleanup function
+    return () => {
+      // Add any cleanup needed for Lenis
+    };
+  }, []);
 
   const images = [
     {
@@ -66,43 +73,34 @@ bg-[var(--color-primary)]
 
   return (
     <div className="min-h-screen bg-[var(--color-bg)] text-[var(--color-text)] transition-colors duration-300">
-      {/* Custom Cursor Component */}
       <GradualBlurEffect/>
       <CustomCursor />
-      <Navbar />
-
-
-
-    
+      <Navbar isDark={isDark} toggleTheme={toggleTheme} /> {/* Added props */}
 
       {/* Sample Pages/Sections for Scrolling */}
       <section id="home" className="min-h-screen flex items-center justify-center bg-[var(--color-bg)]">
         <div className="text-center">
-           <h1 className="relative text-5xl md:text-6xl  ml-8 font-montblanc font-bold text-[var(--color-text)] mb-4">
-        {"Home Section".split(" ").map((word, index) => (
-          <motion.span
-            key={index}
-            initial={{ opacity: 0, filter: "blur(4px)", y: 10 }}
-            animate={{ opacity: 1, filter: "blur(0px)", y: 0 }}
-            transition={{
-              duration: 0.3,
-              delay: index * 0.1,
-              ease: "easeInOut",
-            }}
-            className="mr-[30px] inline-block"
-          >
-            {word}
-          </motion.span>
-        ))}
-      </h1>
+          <h1 className="relative text-5xl md:text-6xl ml-8 font-montblanc font-bold text-[var(--color-text)] mb-4">
+            {"Home Section".split(" ").map((word, index) => (
+              <motion.span
+                key={index}
+                initial={{ opacity: 0, filter: "blur(4px)", y: 10 }}
+                animate={{ opacity: 1, filter: "blur(0px)", y: 0 }}
+                transition={{
+                  duration: 0.3,
+                  delay: index * 0.1,
+                  ease: "easeInOut",
+                }}
+                className="mr-[30px] inline-block"
+              >
+                {word}
+              </motion.span>
+            ))}
+          </h1>
           <p className="text-lg md:text-xl text-[var(--color-text)] opacity-70 max-w-2xl mx-auto">
             This is the home section. The navbar will automatically highlight "Home" when you're in this area.
           </p>
-            {/*for Hero section with blur and on load word by word animation*/}
-      
-      {/*hero section end*/}
         </div>
-        
       </section>
 
       <section id="about" className="min-h-screen flex items-center justify-center bg-[var(--color-primary)]">
@@ -136,8 +134,7 @@ bg-[var(--color-primary)]
           </button>
         </div>
       </section>
-     <ScrollToTopButton />
-      {/* <NoiseEffect /> */}
+      <ScrollToTopButton />
     </div>
   );
 }

--- a/Templates/brand_template1/src/components/CustomCursor.jsx
+++ b/Templates/brand_template1/src/components/CustomCursor.jsx
@@ -94,29 +94,60 @@ const CustomCursor = () => {
     };
   }, [isMobile]);
 
+  const isElementInteractive = (element) => {
+  if (!element) return false;
+  
+  // Check common interactive elements
+  const interactiveSelectors = [
+    'a', 'button', 'input', 'textarea', 'select', 'label',
+    '[role="button"]', '[role="link"]', '[tabindex]',
+    '[onclick]', '[data-clickable]'
+  ];
+  
+  // Check if element matches any interactive selector
+  if (interactiveSelectors.some(selector => element.matches(selector))) {
+    return true;
+  }
+  
+  // Check if element has cursor: pointer style
+  const style = window.getComputedStyle(element);
+  if (style.cursor === 'pointer' || style.cursor === 'grab') {
+    return true;
+  }
+  
+  // Check if element is contenteditable
+  if (element.hasAttribute('contenteditable')) {
+    return true;
+  }
+  
+  return false;
+};
+
+
   // Check if hovering over interactive elements
   const isHoveringInteractive = (x, y) => {
-    try {
-      if (!document.elementFromPoint || !isFinite(x) || !isFinite(y)) {
-        return false;
-      }
-      
-      const element = document.elementFromPoint(x, y);
-      if (!element) return false;
-      
-      const hoverTags = ["A", "BUTTON", "INPUT", "TEXTAREA", "LABEL", "SELECT"];
-      const tagName = element.tagName;
-      
-      const hasClickHandler = element.onclick !== null || 
-                            element.getAttribute('onclick') !== null ||
-                            element.style.cursor === 'pointer' ||
-                            (element.hasAttribute('role') && element.getAttribute('role') === 'button');
-      
-      return (tagName && hoverTags.includes(tagName)) || hasClickHandler;
-    } catch (error) {
+  try {
+    if (!document.elementFromPoint || !isFinite(x) || !isFinite(y)) {
       return false;
     }
-  };
+    
+    const element = document.elementFromPoint(x, y);
+    if (!element) return false;
+    
+    // Check if the element or any of its parents are interactive
+    let currentElement = element;
+    while (currentElement && currentElement !== document.body) {
+      if (isElementInteractive(currentElement)) {
+        return true;
+      }
+      currentElement = currentElement.parentElement;
+    }
+    
+    return false;
+  } catch (error) {
+    return false;
+  }
+};
 
   // Mouse move handler
   const handleMouseMove = (e) => {

--- a/Templates/brand_template1/src/components/ErrorBoundary.jsx
+++ b/Templates/brand_template1/src/components/ErrorBoundary.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null, errorInfo: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({
+      error: error,
+      errorInfo: errorInfo
+    });
+    console.error('Error caught by boundary:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4 bg-red-100 text-red-800">
+          <h2>Something went wrong.</h2>
+          <details style={{ whiteSpace: 'pre-wrap' }}>
+            {this.state.error && this.state.error.toString()}
+            <br />
+            {this.state.errorInfo.componentStack}
+          </details>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/Templates/brand_template1/src/components/Nav2.jsx
+++ b/Templates/brand_template1/src/components/Nav2.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const Navbar = () => {
+const Navbar = ({ isDark, toggleTheme }) => { // Added props
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
   const [activeItem, setActiveItem] = React.useState("Home");
   const [isMobile, setIsMobile] = React.useState(window.innerWidth < 640);
@@ -86,8 +86,6 @@ const Navbar = () => {
       {/* Fixed Site Name */}
       <div
         className="fixed top-7 left-5 sm:top-10 sm:left-14 z-[70] text-4xl sm:text-5xl font-montblanc font-bold"
-       // style={{ mixBlendMode: "difference", color: "rgb(255, 255, 255)" }}
-  
       >
         SITE NAME
       </div>
@@ -162,7 +160,11 @@ const Navbar = () => {
             className="text-[var(--color-bg)] pt-4 cursor-pointer hover:opacity-60 transition-all duration-300"
             onClick={(e) => {
               e.stopPropagation();
-              document.documentElement.classList.toggle("dark");
+              if (toggleTheme) {
+                toggleTheme();
+              } else {
+                document.documentElement.classList.toggle("dark");
+              }
             }}
             style={{
               opacity: isMenuOpen ? 1 : 0,

--- a/Templates/brand_template1/src/main.jsx
+++ b/Templates/brand_template1/src/main.jsx
@@ -1,7 +1,10 @@
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import ErrorBoundary from './components/ErrorBoundary.jsx'
 
 createRoot(document.getElementById('root')).render(
-  <App />,
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>
 )


### PR DESCRIPTION
Closes #11  
Fixed dark mode resetting to light mode on page refresh.  

Changes made:
- Ensured theme preference is saved in local storage and applied on reload.  
- Cleaned up redundant code in `App.js` and `ThemeProvider`.  

Result:
- Before: Dark mode reverted to light mode on refresh.  
- After: User’s theme preference now persists correctly after refresh.  

Let me know if you’d like any changes or improvements in this PR.
